### PR TITLE
Added class for scanning paths and fixed a bug crossing prime meridian

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 With this repo you can make a **poster**, a **video**, or **interactive plot** of a full .fits image.
 
-Note that this script is written for **astronomy applications**. However, by rewriting some parts in the script, 
+Note that this script is written for **astronomy applications**. However, by rewriting some parts in the script,
 you can also use it for other types of applications. In the example we used the lockman_hole.fits made with LOFAR.\
 Other .fits files from LOFAR can be found here:
 https://lofar-surveys.org/
 
 ### Clone repo
+
 You need to clone this repo with (in the location you want to have the scripts):\
 ```git clone https://github.com/jurjen93/advanced_astro_visualization.git```
 
 ### Install requirements
+
 Go to ```advanced_astro_visualization``` with:\
 ```cd advanced_astro_visualization```\
 Now you can install the requirements and make aliases to simplify commands with:\
@@ -20,8 +22,11 @@ If you get permission denied or access error, please give access with:\
 ```chmod u+x ./setup.sh```
 
 ### Catalogue csv file
-You need to have a catalogue with sources for the poster (for the video it is optional). We have an example given in the folder 'catalogue'.\
+
+You need to have a catalogue with sources for the poster (for the video it is optional). We have an example given in the
+folder 'catalogue'.\
 Use the following fields:
+
 * ```source_id```   -> id of the source
 * ```RA```          -> right ascension of the object
 * ```DEC```         -> declination of the object
@@ -37,21 +42,37 @@ https://sourceforge.net/projects/scribus/files/scribus-devel/1.5.5/scribus-1.5.5
 Run now:\
 ```makeposter```\
 where you can use the following flags
-* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty otherwise.
+
+* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty
+  otherwise.
 * ```-csv``` -> Give a specific csv file with sources to include as cutouts in the poster.
 * ```-fi``` -> Fits file to use. (If you don't download your fits file)
 
 Example:\
 ```makeposter -csv catalogue/catalogue_lockman.csv -fi fits/lockman_hole.fits```
-  
+
 ### How to make the video
+
 Run:\
 ```makevideo```\
 where you can use the following flags
-* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty otherwise.
-* ```-csv``` -> Give a specific csv file with sources to include as cutouts in the poster. If you leave it empty, it goes through the whole field.
-* ```-fr``` -> Frame rate of the video. Advice is to use ```20``` to make the video smooth but doesn't take too long to record.
+
+* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty
+  otherwise.
+* ```-csv``` -> Give a specific csv file with sources to include as cutouts in the poster. If you leave it empty, it
+  goes through the whole field.
+* ```-fr``` -> Frame rate of the video. Advice is to use ```20``` to make the video smooth but doesn't take too long to
+  record.
+* ```-zs``` -> Size in degrees of the zoomed image. If the original image size is smaller than this input, there will be
+  a zoom out.
+* ```-dr``` -> The amount of degrees traversed each second ('degree rate') in the video.
 * ```-fi``` -> Fits file to use. (If you don't download your fits file)
+* ```-sc``` -> Scanning path type of a pan through the whole field. Can be ```'horizontal'``` or ```'spiral'```. New
+  paths can be made with the ```paths.py``` script.
+
+The user should be aware that with increasing -zs the -dr value should decrease in order to get a movie that scans
+slowly over the image.
+The -fr input then controls how smooth the video looks.
 
 Example pan through source by source from your csv file:\
 ```makevideo -csv catalogue/catalogue_lockman.csv -d 1 -f 60```\
@@ -60,6 +81,7 @@ Example of pan through a whole field:\
 In the video one can see the coordinates. If you want to make a separate image from this, you can run the following:\
 ```makeimage -fi fits/your_fits.fits -ra 123.123 -dec 51.123 -si 0.4```\
 where you can use the following flags
+
 * ```-si``` -> Size in degrees.
 * ```-dec``` -> Declination in degrees.
 * ```-ra``` -> Right ascension in degrees.
@@ -69,20 +91,25 @@ See also the following blog for more information:
 https://towardsdatascience.com/how-to-make-a-video-from-your-astronomy-images-957f1d40dea1\
 
 ### How to make the interactive plot
+
 Run:\
 ```makeinteractive```\
 where you can use the following flags
-* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty otherwise.
+
+* ```-d``` -> Choose to download a specific fits file from the internet. Use ```1``` if you want to, leave empty
+  otherwise.
 * ```-fi``` -> Fits file to use. (If you don't download your fits file)
 
 Example:\
 ```makeinteractive -fi fits/your_fits.fits```
 
 ### Output
+
 **Poster**: *poster.pdf*\
 **Video**: *movie.mp4*\
 **Interactive plot**: *interactive.html*
 
 ### Contact/Collaboration
+
 Feel free to send me a message if you want to help me out with improvements or if you have any suggestions.\
 Contact: jurjendejong(AT)strw.leidenuniv.nl

--- a/interactive.html
+++ b/interactive.html
@@ -1,49 +1,396 @@
-
-
-
-
 <!DOCTYPE html>
 <html lang="en">
-  
-  <head>
-    
-      <meta charset="utf-8">
-      <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
-        <script type="text/javascript" src="https://cdn.pydata.org/bokeh/release/bokeh-1.4.0.min.js"></script>
-        <script type="text/javascript">
+
+<head>
+
+    <meta charset="utf-8">
+    <title>Bokeh Plot</title>
+
+
+    <script type="text/javascript" src="https://cdn.pydata.org/bokeh/release/bokeh-1.4.0.min.js"></script>
+    <script type="text/javascript">
             Bokeh.set_log_level("info");
-        </script>
-        
-      
-      
-    
-  </head>
-  
-  
-  <body>
-    
-      
-        
-          
-          
-            
-              <div class="bk-root" id="b59e42d7-1ac0-433e-baac-13298399d12f" data-root-id="1001"></div>
-            
-          
-        
-      
-      
-        <script type="application/json" id="1128">
-          {"756a9dfa-b530-48e6-bd1a-04112a4a625b":{"roots":{"references":[{"attributes":{"active_drag":{"id":"1021","type":"PanTool"},"active_inspect":"auto","active_multi":null,"active_scroll":{"id":"1022","type":"WheelZoomTool"},"active_tap":"auto","tools":[{"id":"1020","type":"HoverTool"},{"id":"1021","type":"PanTool"},{"id":"1022","type":"WheelZoomTool"}]},"id":"1023","type":"Toolbar"},{"attributes":{"data_source":{"id":"1027","type":"ColumnDataSource"},"glyph":{"id":"1028","type":"ImageURL"},"hover_glyph":null,"muted_glyph":null,"nonselection_glyph":{"id":"1029","type":"ImageURL"},"selection_glyph":null,"view":{"id":"1031","type":"CDSView"}},"id":"1030","type":"GlyphRenderer"},{"attributes":{"text":""},"id":"1032","type":"Title"},{"attributes":{},"id":"1021","type":"PanTool"},{"attributes":{"ticker":{"id":"1011","type":"BasicTicker"},"visible":false},"id":"1014","type":"Grid"},{"attributes":{},"id":"1039","type":"UnionRenderers"},{"attributes":{"dimension":1,"ticker":{"id":"1016","type":"BasicTicker"},"visible":false},"id":"1019","type":"Grid"},{"attributes":{},"id":"1036","type":"BasicTickFormatter"},{"attributes":{},"id":"1016","type":"BasicTicker"},{"attributes":{"h":{"units":"data","value":0.416334010883908},"url":{"field":"url"},"w":{"units":"data","value":0.7270338201619779},"x":{"value":205.36142043645785},"y":{"value":55.207897454263446}},"id":"1028","type":"ImageURL"},{"attributes":{"callback":null,"end":55.207897454263446,"start":54.79156344337954},"id":"1004","type":"Range1d"},{"attributes":{},"id":"1038","type":"Selection"},{"attributes":{"axis_label":"DEC (deg)","axis_label_text_font_style":"bold","formatter":{"id":"1036","type":"BasicTickFormatter"},"major_tick_line_color":{"value":"firebrick"},"major_tick_line_width":{"value":3},"major_tick_out":10,"minor_tick_in":-3,"minor_tick_line_color":{"value":"orange"},"minor_tick_out":8,"ticker":{"id":"1016","type":"BasicTicker"}},"id":"1015","type":"LinearAxis"},{"attributes":{},"id":"1022","type":"WheelZoomTool"},{"attributes":{"source":{"id":"1027","type":"ColumnDataSource"}},"id":"1031","type":"CDSView"},{"attributes":{"h":{"units":"data","value":0.416334010883908},"url":{"field":"url"},"w":{"units":"data","value":0.7270338201619779},"x":{"value":205.36142043645785},"y":{"value":55.207897454263446}},"id":"1029","type":"ImageURL"},{"attributes":{"callback":null,"end":204.63438661629587,"start":205.36142043645785},"id":"1002","type":"Range1d"},{"attributes":{},"id":"1034","type":"BasicTickFormatter"},{"attributes":{},"id":"1006","type":"LinearScale"},{"attributes":{"axis_label":"RA (deg)","axis_label_text_font_style":"bold","formatter":{"id":"1034","type":"BasicTickFormatter"},"major_tick_line_color":{"value":"firebrick"},"major_tick_line_width":{"value":3},"major_tick_out":10,"minor_tick_in":-3,"minor_tick_line_color":{"value":"orange"},"minor_tick_out":8,"ticker":{"id":"1011","type":"BasicTicker"}},"id":"1010","type":"LinearAxis"},{"attributes":{"below":[{"id":"1010","type":"LinearAxis"}],"center":[{"id":"1014","type":"Grid"},{"id":"1019","type":"Grid"}],"left":[{"id":"1015","type":"LinearAxis"}],"renderers":[{"id":"1030","type":"GlyphRenderer"}],"title":{"id":"1032","type":"Title"},"toolbar":{"id":"1023","type":"Toolbar"},"x_range":{"id":"1002","type":"Range1d"},"x_scale":{"id":"1006","type":"LinearScale"},"y_range":{"id":"1004","type":"Range1d"},"y_scale":{"id":"1008","type":"LinearScale"}},"id":"1001","subtype":"Figure","type":"Plot"},{"attributes":{},"id":"1011","type":"BasicTicker"},{"attributes":{"callback":null,"data":{"url":["interactive_plot/images/main.png"]},"selected":{"id":"1038","type":"Selection"},"selection_policy":{"id":"1039","type":"UnionRenderers"}},"id":"1027","type":"ColumnDataSource"},{"attributes":{},"id":"1008","type":"LinearScale"},{"attributes":{"callback":null},"id":"1020","type":"HoverTool"}],"root_ids":["1001"]},"title":"Bokeh Application","version":"1.4.0"}}
-        </script>
-        <script type="text/javascript">
+
+    </script>
+
+
+</head>
+
+
+<body>
+
+
+<div class="bk-root" id="b59e42d7-1ac0-433e-baac-13298399d12f" data-root-id="1001"></div>
+
+
+<script type="application/json" id="1128">
+    {
+        "756a9dfa-b530-48e6-bd1a-04112a4a625b": {
+            "roots": {
+                "references": [
+                    {
+                        "attributes": {
+                            "active_drag": {
+                                "id": "1021",
+                                "type": "PanTool"
+                            },
+                            "active_inspect": "auto",
+                            "active_multi": null,
+                            "active_scroll": {
+                                "id": "1022",
+                                "type": "WheelZoomTool"
+                            },
+                            "active_tap": "auto",
+                            "tools": [
+                                {
+                                    "id": "1020",
+                                    "type": "HoverTool"
+                                },
+                                {
+                                    "id": "1021",
+                                    "type": "PanTool"
+                                },
+                                {
+                                    "id": "1022",
+                                    "type": "WheelZoomTool"
+                                }
+                            ]
+                        },
+                        "id": "1023",
+                        "type": "Toolbar"
+                    },
+                    {
+                        "attributes": {
+                            "data_source": {
+                                "id": "1027",
+                                "type": "ColumnDataSource"
+                            },
+                            "glyph": {
+                                "id": "1028",
+                                "type": "ImageURL"
+                            },
+                            "hover_glyph": null,
+                            "muted_glyph": null,
+                            "nonselection_glyph": {
+                                "id": "1029",
+                                "type": "ImageURL"
+                            },
+                            "selection_glyph": null,
+                            "view": {
+                                "id": "1031",
+                                "type": "CDSView"
+                            }
+                        },
+                        "id": "1030",
+                        "type": "GlyphRenderer"
+                    },
+                    {
+                        "attributes": {
+                            "text": ""
+                        },
+                        "id": "1032",
+                        "type": "Title"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1021",
+                        "type": "PanTool"
+                    },
+                    {
+                        "attributes": {
+                            "ticker": {
+                                "id": "1011",
+                                "type": "BasicTicker"
+                            },
+                            "visible": false
+                        },
+                        "id": "1014",
+                        "type": "Grid"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1039",
+                        "type": "UnionRenderers"
+                    },
+                    {
+                        "attributes": {
+                            "dimension": 1,
+                            "ticker": {
+                                "id": "1016",
+                                "type": "BasicTicker"
+                            },
+                            "visible": false
+                        },
+                        "id": "1019",
+                        "type": "Grid"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1036",
+                        "type": "BasicTickFormatter"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1016",
+                        "type": "BasicTicker"
+                    },
+                    {
+                        "attributes": {
+                            "h": {
+                                "units": "data",
+                                "value": 0.416334010883908
+                            },
+                            "url": {
+                                "field": "url"
+                            },
+                            "w": {
+                                "units": "data",
+                                "value": 0.7270338201619779
+                            },
+                            "x": {
+                                "value": 205.36142043645785
+                            },
+                            "y": {
+                                "value": 55.207897454263446
+                            }
+                        },
+                        "id": "1028",
+                        "type": "ImageURL"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "end": 55.207897454263446,
+                            "start": 54.79156344337954
+                        },
+                        "id": "1004",
+                        "type": "Range1d"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1038",
+                        "type": "Selection"
+                    },
+                    {
+                        "attributes": {
+                            "axis_label": "DEC (deg)",
+                            "axis_label_text_font_style": "bold",
+                            "formatter": {
+                                "id": "1036",
+                                "type": "BasicTickFormatter"
+                            },
+                            "major_tick_line_color": {
+                                "value": "firebrick"
+                            },
+                            "major_tick_line_width": {
+                                "value": 3
+                            },
+                            "major_tick_out": 10,
+                            "minor_tick_in": -3,
+                            "minor_tick_line_color": {
+                                "value": "orange"
+                            },
+                            "minor_tick_out": 8,
+                            "ticker": {
+                                "id": "1016",
+                                "type": "BasicTicker"
+                            }
+                        },
+                        "id": "1015",
+                        "type": "LinearAxis"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1022",
+                        "type": "WheelZoomTool"
+                    },
+                    {
+                        "attributes": {
+                            "source": {
+                                "id": "1027",
+                                "type": "ColumnDataSource"
+                            }
+                        },
+                        "id": "1031",
+                        "type": "CDSView"
+                    },
+                    {
+                        "attributes": {
+                            "h": {
+                                "units": "data",
+                                "value": 0.416334010883908
+                            },
+                            "url": {
+                                "field": "url"
+                            },
+                            "w": {
+                                "units": "data",
+                                "value": 0.7270338201619779
+                            },
+                            "x": {
+                                "value": 205.36142043645785
+                            },
+                            "y": {
+                                "value": 55.207897454263446
+                            }
+                        },
+                        "id": "1029",
+                        "type": "ImageURL"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "end": 204.63438661629587,
+                            "start": 205.36142043645785
+                        },
+                        "id": "1002",
+                        "type": "Range1d"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1034",
+                        "type": "BasicTickFormatter"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1006",
+                        "type": "LinearScale"
+                    },
+                    {
+                        "attributes": {
+                            "axis_label": "RA (deg)",
+                            "axis_label_text_font_style": "bold",
+                            "formatter": {
+                                "id": "1034",
+                                "type": "BasicTickFormatter"
+                            },
+                            "major_tick_line_color": {
+                                "value": "firebrick"
+                            },
+                            "major_tick_line_width": {
+                                "value": 3
+                            },
+                            "major_tick_out": 10,
+                            "minor_tick_in": -3,
+                            "minor_tick_line_color": {
+                                "value": "orange"
+                            },
+                            "minor_tick_out": 8,
+                            "ticker": {
+                                "id": "1011",
+                                "type": "BasicTicker"
+                            }
+                        },
+                        "id": "1010",
+                        "type": "LinearAxis"
+                    },
+                    {
+                        "attributes": {
+                            "below": [
+                                {
+                                    "id": "1010",
+                                    "type": "LinearAxis"
+                                }
+                            ],
+                            "center": [
+                                {
+                                    "id": "1014",
+                                    "type": "Grid"
+                                },
+                                {
+                                    "id": "1019",
+                                    "type": "Grid"
+                                }
+                            ],
+                            "left": [
+                                {
+                                    "id": "1015",
+                                    "type": "LinearAxis"
+                                }
+                            ],
+                            "renderers": [
+                                {
+                                    "id": "1030",
+                                    "type": "GlyphRenderer"
+                                }
+                            ],
+                            "title": {
+                                "id": "1032",
+                                "type": "Title"
+                            },
+                            "toolbar": {
+                                "id": "1023",
+                                "type": "Toolbar"
+                            },
+                            "x_range": {
+                                "id": "1002",
+                                "type": "Range1d"
+                            },
+                            "x_scale": {
+                                "id": "1006",
+                                "type": "LinearScale"
+                            },
+                            "y_range": {
+                                "id": "1004",
+                                "type": "Range1d"
+                            },
+                            "y_scale": {
+                                "id": "1008",
+                                "type": "LinearScale"
+                            }
+                        },
+                        "id": "1001",
+                        "subtype": "Figure",
+                        "type": "Plot"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1011",
+                        "type": "BasicTicker"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "data": {
+                                "url": [
+                                    "interactive_plot/images/main.png"
+                                ]
+                            },
+                            "selected": {
+                                "id": "1038",
+                                "type": "Selection"
+                            },
+                            "selection_policy": {
+                                "id": "1039",
+                                "type": "UnionRenderers"
+                            }
+                        },
+                        "id": "1027",
+                        "type": "ColumnDataSource"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1008",
+                        "type": "LinearScale"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null
+                        },
+                        "id": "1020",
+                        "type": "HoverTool"
+                    }
+                ],
+                "root_ids": [
+                    "1001"
+                ]
+            },
+            "title": "Bokeh Application",
+            "version": "1.4.0"
+        }
+    }
+</script>
+<script type="text/javascript">
           (function() {
             var fn = function() {
               Bokeh.safely(function() {
@@ -78,8 +425,9 @@
             if (document.readyState != "loading") fn();
             else document.addEventListener("DOMContentLoaded", fn);
           })();
-        </script>
-    
-  </body>
-  
+
+</script>
+
+</body>
+
 </html>

--- a/interactive_example.html
+++ b/interactive_example.html
@@ -1,49 +1,396 @@
-
-
-
-
 <!DOCTYPE html>
 <html lang="en">
-  
-  <head>
-    
-      <meta charset="utf-8">
-      <title>Bokeh Plot</title>
-      
-      
-        
-          
-        
-        
-          
-        <script type="text/javascript" src="https://cdn.pydata.org/bokeh/release/bokeh-1.4.0.min.js"></script>
-        <script type="text/javascript">
+
+<head>
+
+    <meta charset="utf-8">
+    <title>Bokeh Plot</title>
+
+
+    <script type="text/javascript" src="https://cdn.pydata.org/bokeh/release/bokeh-1.4.0.min.js"></script>
+    <script type="text/javascript">
             Bokeh.set_log_level("info");
-        </script>
-        
-      
-      
-    
-  </head>
-  
-  
-  <body>
-    
-      
-        
-          
-          
-            
-              <div class="bk-root" id="d9254615-0e32-46b6-8062-39d562276f00" data-root-id="1001"></div>
-            
-          
-        
-      
-      
-        <script type="application/json" id="1128">
-          {"c8226b23-5369-4a62-bf90-52830c20e596":{"roots":{"references":[{"attributes":{"data_source":{"id":"1027","type":"ColumnDataSource"},"glyph":{"id":"1028","type":"ImageURL"},"hover_glyph":null,"muted_glyph":null,"nonselection_glyph":{"id":"1029","type":"ImageURL"},"selection_glyph":null,"view":{"id":"1031","type":"CDSView"}},"id":"1030","type":"GlyphRenderer"},{"attributes":{},"id":"1006","type":"LinearScale"},{"attributes":{"h":{"units":"data","value":5.8162654429796135},"url":{"field":"url"},"w":{"units":"data","value":11.10157370314559},"x":{"value":166.84876324230063},"y":{"value":60.87126448849653}},"id":"1029","type":"ImageURL"},{"attributes":{"dimension":1,"ticker":{"id":"1016","type":"BasicTicker"},"visible":false},"id":"1019","type":"Grid"},{"attributes":{"active_drag":{"id":"1021","type":"PanTool"},"active_inspect":"auto","active_multi":null,"active_scroll":{"id":"1022","type":"WheelZoomTool"},"active_tap":"auto","tools":[{"id":"1020","type":"HoverTool"},{"id":"1021","type":"PanTool"},{"id":"1022","type":"WheelZoomTool"}]},"id":"1023","type":"Toolbar"},{"attributes":{},"id":"1008","type":"LinearScale"},{"attributes":{"h":{"units":"data","value":5.8162654429796135},"url":{"field":"url"},"w":{"units":"data","value":11.10157370314559},"x":{"value":166.84876324230063},"y":{"value":60.87126448849653}},"id":"1028","type":"ImageURL"},{"attributes":{"callback":null,"data":{"url":["interactive_plot/images/main.png"]},"selected":{"id":"1039","type":"Selection"},"selection_policy":{"id":"1038","type":"UnionRenderers"}},"id":"1027","type":"ColumnDataSource"},{"attributes":{"callback":null},"id":"1020","type":"HoverTool"},{"attributes":{"text":""},"id":"1032","type":"Title"},{"attributes":{},"id":"1034","type":"BasicTickFormatter"},{"attributes":{"axis_label":"RA (deg)","axis_label_text_font_style":"bold","formatter":{"id":"1034","type":"BasicTickFormatter"},"major_tick_line_color":{"value":"firebrick"},"major_tick_line_width":{"value":3},"major_tick_out":10,"minor_tick_in":-3,"minor_tick_line_color":{"value":"orange"},"minor_tick_out":8,"ticker":{"id":"1011","type":"BasicTicker"}},"id":"1010","type":"LinearAxis"},{"attributes":{},"id":"1022","type":"WheelZoomTool"},{"attributes":{"below":[{"id":"1010","type":"LinearAxis"}],"center":[{"id":"1014","type":"Grid"},{"id":"1019","type":"Grid"}],"left":[{"id":"1015","type":"LinearAxis"}],"renderers":[{"id":"1030","type":"GlyphRenderer"}],"title":{"id":"1032","type":"Title"},"toolbar":{"id":"1023","type":"Toolbar"},"x_range":{"id":"1002","type":"Range1d"},"x_scale":{"id":"1006","type":"LinearScale"},"y_range":{"id":"1004","type":"Range1d"},"y_scale":{"id":"1008","type":"LinearScale"}},"id":"1001","subtype":"Figure","type":"Plot"},{"attributes":{"callback":null,"end":155.74718953915504,"start":166.84876324230063},"id":"1002","type":"Range1d"},{"attributes":{"callback":null,"end":60.87126448849653,"start":55.054999045516915},"id":"1004","type":"Range1d"},{"attributes":{},"id":"1021","type":"PanTool"},{"attributes":{},"id":"1016","type":"BasicTicker"},{"attributes":{"source":{"id":"1027","type":"ColumnDataSource"}},"id":"1031","type":"CDSView"},{"attributes":{"ticker":{"id":"1011","type":"BasicTicker"},"visible":false},"id":"1014","type":"Grid"},{"attributes":{},"id":"1011","type":"BasicTicker"},{"attributes":{},"id":"1039","type":"Selection"},{"attributes":{"axis_label":"DEC (deg)","axis_label_text_font_style":"bold","formatter":{"id":"1036","type":"BasicTickFormatter"},"major_tick_line_color":{"value":"firebrick"},"major_tick_line_width":{"value":3},"major_tick_out":10,"minor_tick_in":-3,"minor_tick_line_color":{"value":"orange"},"minor_tick_out":8,"ticker":{"id":"1016","type":"BasicTicker"}},"id":"1015","type":"LinearAxis"},{"attributes":{},"id":"1036","type":"BasicTickFormatter"},{"attributes":{},"id":"1038","type":"UnionRenderers"}],"root_ids":["1001"]},"title":"Bokeh Application","version":"1.4.0"}}
-        </script>
-        <script type="text/javascript">
+
+    </script>
+
+
+</head>
+
+
+<body>
+
+
+<div class="bk-root" id="d9254615-0e32-46b6-8062-39d562276f00" data-root-id="1001"></div>
+
+
+<script type="application/json" id="1128">
+    {
+        "c8226b23-5369-4a62-bf90-52830c20e596": {
+            "roots": {
+                "references": [
+                    {
+                        "attributes": {
+                            "data_source": {
+                                "id": "1027",
+                                "type": "ColumnDataSource"
+                            },
+                            "glyph": {
+                                "id": "1028",
+                                "type": "ImageURL"
+                            },
+                            "hover_glyph": null,
+                            "muted_glyph": null,
+                            "nonselection_glyph": {
+                                "id": "1029",
+                                "type": "ImageURL"
+                            },
+                            "selection_glyph": null,
+                            "view": {
+                                "id": "1031",
+                                "type": "CDSView"
+                            }
+                        },
+                        "id": "1030",
+                        "type": "GlyphRenderer"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1006",
+                        "type": "LinearScale"
+                    },
+                    {
+                        "attributes": {
+                            "h": {
+                                "units": "data",
+                                "value": 5.8162654429796135
+                            },
+                            "url": {
+                                "field": "url"
+                            },
+                            "w": {
+                                "units": "data",
+                                "value": 11.10157370314559
+                            },
+                            "x": {
+                                "value": 166.84876324230063
+                            },
+                            "y": {
+                                "value": 60.87126448849653
+                            }
+                        },
+                        "id": "1029",
+                        "type": "ImageURL"
+                    },
+                    {
+                        "attributes": {
+                            "dimension": 1,
+                            "ticker": {
+                                "id": "1016",
+                                "type": "BasicTicker"
+                            },
+                            "visible": false
+                        },
+                        "id": "1019",
+                        "type": "Grid"
+                    },
+                    {
+                        "attributes": {
+                            "active_drag": {
+                                "id": "1021",
+                                "type": "PanTool"
+                            },
+                            "active_inspect": "auto",
+                            "active_multi": null,
+                            "active_scroll": {
+                                "id": "1022",
+                                "type": "WheelZoomTool"
+                            },
+                            "active_tap": "auto",
+                            "tools": [
+                                {
+                                    "id": "1020",
+                                    "type": "HoverTool"
+                                },
+                                {
+                                    "id": "1021",
+                                    "type": "PanTool"
+                                },
+                                {
+                                    "id": "1022",
+                                    "type": "WheelZoomTool"
+                                }
+                            ]
+                        },
+                        "id": "1023",
+                        "type": "Toolbar"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1008",
+                        "type": "LinearScale"
+                    },
+                    {
+                        "attributes": {
+                            "h": {
+                                "units": "data",
+                                "value": 5.8162654429796135
+                            },
+                            "url": {
+                                "field": "url"
+                            },
+                            "w": {
+                                "units": "data",
+                                "value": 11.10157370314559
+                            },
+                            "x": {
+                                "value": 166.84876324230063
+                            },
+                            "y": {
+                                "value": 60.87126448849653
+                            }
+                        },
+                        "id": "1028",
+                        "type": "ImageURL"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "data": {
+                                "url": [
+                                    "interactive_plot/images/main.png"
+                                ]
+                            },
+                            "selected": {
+                                "id": "1039",
+                                "type": "Selection"
+                            },
+                            "selection_policy": {
+                                "id": "1038",
+                                "type": "UnionRenderers"
+                            }
+                        },
+                        "id": "1027",
+                        "type": "ColumnDataSource"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null
+                        },
+                        "id": "1020",
+                        "type": "HoverTool"
+                    },
+                    {
+                        "attributes": {
+                            "text": ""
+                        },
+                        "id": "1032",
+                        "type": "Title"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1034",
+                        "type": "BasicTickFormatter"
+                    },
+                    {
+                        "attributes": {
+                            "axis_label": "RA (deg)",
+                            "axis_label_text_font_style": "bold",
+                            "formatter": {
+                                "id": "1034",
+                                "type": "BasicTickFormatter"
+                            },
+                            "major_tick_line_color": {
+                                "value": "firebrick"
+                            },
+                            "major_tick_line_width": {
+                                "value": 3
+                            },
+                            "major_tick_out": 10,
+                            "minor_tick_in": -3,
+                            "minor_tick_line_color": {
+                                "value": "orange"
+                            },
+                            "minor_tick_out": 8,
+                            "ticker": {
+                                "id": "1011",
+                                "type": "BasicTicker"
+                            }
+                        },
+                        "id": "1010",
+                        "type": "LinearAxis"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1022",
+                        "type": "WheelZoomTool"
+                    },
+                    {
+                        "attributes": {
+                            "below": [
+                                {
+                                    "id": "1010",
+                                    "type": "LinearAxis"
+                                }
+                            ],
+                            "center": [
+                                {
+                                    "id": "1014",
+                                    "type": "Grid"
+                                },
+                                {
+                                    "id": "1019",
+                                    "type": "Grid"
+                                }
+                            ],
+                            "left": [
+                                {
+                                    "id": "1015",
+                                    "type": "LinearAxis"
+                                }
+                            ],
+                            "renderers": [
+                                {
+                                    "id": "1030",
+                                    "type": "GlyphRenderer"
+                                }
+                            ],
+                            "title": {
+                                "id": "1032",
+                                "type": "Title"
+                            },
+                            "toolbar": {
+                                "id": "1023",
+                                "type": "Toolbar"
+                            },
+                            "x_range": {
+                                "id": "1002",
+                                "type": "Range1d"
+                            },
+                            "x_scale": {
+                                "id": "1006",
+                                "type": "LinearScale"
+                            },
+                            "y_range": {
+                                "id": "1004",
+                                "type": "Range1d"
+                            },
+                            "y_scale": {
+                                "id": "1008",
+                                "type": "LinearScale"
+                            }
+                        },
+                        "id": "1001",
+                        "subtype": "Figure",
+                        "type": "Plot"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "end": 155.74718953915504,
+                            "start": 166.84876324230063
+                        },
+                        "id": "1002",
+                        "type": "Range1d"
+                    },
+                    {
+                        "attributes": {
+                            "callback": null,
+                            "end": 60.87126448849653,
+                            "start": 55.054999045516915
+                        },
+                        "id": "1004",
+                        "type": "Range1d"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1021",
+                        "type": "PanTool"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1016",
+                        "type": "BasicTicker"
+                    },
+                    {
+                        "attributes": {
+                            "source": {
+                                "id": "1027",
+                                "type": "ColumnDataSource"
+                            }
+                        },
+                        "id": "1031",
+                        "type": "CDSView"
+                    },
+                    {
+                        "attributes": {
+                            "ticker": {
+                                "id": "1011",
+                                "type": "BasicTicker"
+                            },
+                            "visible": false
+                        },
+                        "id": "1014",
+                        "type": "Grid"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1011",
+                        "type": "BasicTicker"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1039",
+                        "type": "Selection"
+                    },
+                    {
+                        "attributes": {
+                            "axis_label": "DEC (deg)",
+                            "axis_label_text_font_style": "bold",
+                            "formatter": {
+                                "id": "1036",
+                                "type": "BasicTickFormatter"
+                            },
+                            "major_tick_line_color": {
+                                "value": "firebrick"
+                            },
+                            "major_tick_line_width": {
+                                "value": 3
+                            },
+                            "major_tick_out": 10,
+                            "minor_tick_in": -3,
+                            "minor_tick_line_color": {
+                                "value": "orange"
+                            },
+                            "minor_tick_out": 8,
+                            "ticker": {
+                                "id": "1016",
+                                "type": "BasicTicker"
+                            }
+                        },
+                        "id": "1015",
+                        "type": "LinearAxis"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1036",
+                        "type": "BasicTickFormatter"
+                    },
+                    {
+                        "attributes": {},
+                        "id": "1038",
+                        "type": "UnionRenderers"
+                    }
+                ],
+                "root_ids": [
+                    "1001"
+                ]
+            },
+            "title": "Bokeh Application",
+            "version": "1.4.0"
+        }
+    }
+</script>
+<script type="text/javascript">
           (function() {
             var fn = function() {
               Bokeh.safely(function() {
@@ -78,8 +425,9 @@
             if (document.readyState != "loading") fn();
             else document.addEventListener("DOMContentLoaded", fn);
           })();
-        </script>
-    
-  </body>
-  
+
+</script>
+
+</body>
+
 </html>

--- a/interactive_plot/scripts/interactive_plot.py
+++ b/interactive_plot/scripts/interactive_plot.py
@@ -1,26 +1,39 @@
 from bokeh.plotting import figure, show, output_file
+
 from poster.scripts.imaging import ImagingLofar
 
+
 class Interactive(ImagingLofar):
-    def __init__(self, fits_file: str=None, fits_download: bool=False):
-        super().__init__(fits_file=fits_file, image_directory='interactive_plot/images',
-                         verbose=False, fits_download=fits_download, interactive=True)
+    def __init__(self, fits_file: str = None, fits_download: bool = False):
+        super().__init__(
+            fits_file=fits_file,
+            image_directory="interactive_plot/images",
+            verbose=False,
+            fits_download=fits_download,
+            interactive=True,
+        )
 
     def html_from_png(self):
-
-        output_file('interactive.html')
+        output_file("interactive.html")
         x_low, y_low = list(float(i) for i in self.wcs.array_index_to_world_values(0, 0))
-        x_high, y_high = list(float(i) for i in self.wcs.array_index_to_world_values(self.image_data.shape[0], self.image_data.shape[1]))
+        x_high, y_high = list(
+            float(i) for i in self.wcs.array_index_to_world_values(self.image_data.shape[0], self.image_data.shape[1])
+        )
         print(x_low, y_low)
         print(x_high, y_high)
-        p = figure(x_range=(x_low, x_high), y_range=(y_low, y_high), tools='hover,pan,wheel_zoom',
-                   active_scroll='wheel_zoom', active_drag='pan')
-        p.image_url(['interactive_plot/images/main.png'], x=x_low, y=y_high, h=y_high-y_low, w=x_low-x_high)
+        p = figure(
+            x_range=(x_low, x_high),
+            y_range=(y_low, y_high),
+            tools="hover,pan,wheel_zoom",
+            active_scroll="wheel_zoom",
+            active_drag="pan",
+        )
+        p.image_url(["interactive_plot/images/main.png"], x=x_low, y=y_high, h=y_high - y_low, w=x_low - x_high)
         p.xgrid.visible = False
         p.ygrid.visible = False
 
-        p.xaxis.axis_label = 'RA (deg)'
-        p.yaxis.axis_label = 'DEC (deg)'
+        p.xaxis.axis_label = "RA (deg)"
+        p.yaxis.axis_label = "DEC (deg)"
         p.xaxis.axis_label_text_font_style = "bold"
         p.yaxis.axis_label_text_font_style = "bold"
 
@@ -38,5 +51,6 @@ class Interactive(ImagingLofar):
 
         show(p)
 
-if __name__ == '__main__':
-    print('Cannot call script directly.')
+
+if __name__ == "__main__":
+    print("Cannot call script directly.")

--- a/make_image.py
+++ b/make_image.py
@@ -1,13 +1,14 @@
-from poster.scripts.imaging import ImagingLofar
 import argparse
 import os
 
+from poster.scripts.imaging import ImagingLofar
+
 parser = argparse.ArgumentParser("Make cutout image from fits file.")
-parser.add_argument('-fi', '--fits', type=str, help='Fits file to use')
-parser.add_argument('-ra', '--right_ascension', type=float, help='RA in degrees')
-parser.add_argument('-dec', '--declination', type=float, help='DEC in degrees')
-parser.add_argument('-si', '--image_size', type=float, help='Image size in degrees (for squared region)')
-parser.add_argument('-ia', '--interactive', type=bool, default=True, help='Display image in interactive mode')
+parser.add_argument("-fi", "--fits", type=str, help="Fits file to use")
+parser.add_argument("-ra", "--right_ascension", type=float, help="RA in degrees")
+parser.add_argument("-dec", "--declination", type=float, help="DEC in degrees")
+parser.add_argument("-si", "--image_size", type=float, help="Image size in degrees (for squared region)")
+parser.add_argument("-ia", "--interactive", type=bool, default=True, help="Display image in interactive mode")
 args = parser.parse_args()
 
 if args.image_size:
@@ -15,15 +16,13 @@ if args.image_size:
 else:
     imsize = 0.4
 
-filename = '_'.join(args.fits.split('/')[-1].split('.')[0:-1]+[str(args.right_ascension), str(args.declination)])
+filename = "_".join(args.fits.split("/")[-1].split(".")[0:-1] + [str(args.right_ascension), str(args.declination)])
 
-Image = ImagingLofar(fits_file=args.fits, image_directory='cutouts', verbose=False)
-Image.image_cutout(image_name=filename+'.png',
-              dpi=100, pos=(args.right_ascension, args.declination), imsize=imsize)
-print(f'Made {filename}.png')
-Image.make_fits(pos=(args.right_ascension, args.declination), imsize=0.4,
-                filename=filename+'.fits')
-print(f'Made {filename}.fits')
+Image = ImagingLofar(fits_file=args.fits, image_directory="cutouts", verbose=False)
+Image.image_cutout(image_name=filename + ".png", dpi=100, pos=(args.right_ascension, args.declination), imsize=imsize)
+print(f"Made {filename}.png")
+Image.make_fits(pos=(args.right_ascension, args.declination), imsize=0.4, filename=filename + ".fits")
+print(f"Made {filename}.fits")
 
 if args.interactive:
-    os.system(f'python make_interactive.py -fi cutouts/{filename}.fits')
+    os.system(f"python make_interactive.py -fi cutouts/{filename}.fits")

--- a/make_interactive.py
+++ b/make_interactive.py
@@ -1,25 +1,27 @@
-from interactive_plot.scripts.interactive_plot import Interactive
 import argparse
+
 from astropy.utils.data import get_pkg_data_filename
 
+from interactive_plot.scripts.interactive_plot import Interactive
+
 parser = argparse.ArgumentParser("Make interactive plo from fits file.")
-parser.add_argument('-d', '--downloading', type=int, help='download your own data')
-parser.add_argument('-fi', '--fits', type=str, help='fits file to use')
+parser.add_argument("-d", "--downloading", type=int, help="download your own data")
+parser.add_argument("-fi", "--fits", type=str, help="fits file to use")
 args = parser.parse_args()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if args.downloading == 1:
-        download = input('Paste here your url where to find the fits file: ')
-        fits_download=True
+        download = input("Paste here your url where to find the fits file: ")
+        fits_download = True
         Image = Interactive(fits_download=True)
     else:
         fits_download = False
         if args.fits:
             file = args.fits
         else:
-            file = 'fits/mosaic-blanked.fits'
+            file = "fits/mosaic-blanked.fits"
         Image = Interactive(fits_file=get_pkg_data_filename(file))
 
     image = Interactive(fits_file=file)
-    image.imaging(image_name='main.png', save=True, dpi=750)
+    image.imaging(image_name="main.png", save=True, dpi=750)
     image.html_from_png()

--- a/make_movie.py
+++ b/make_movie.py
@@ -1,135 +1,120 @@
-import warnings
-from video.scripts.moviemaker import MovieMaker
-from astropy.utils.data import get_pkg_data_filename
-from timeit import default_timer as timer
-import pandas as pd
 import argparse
-from numpy import sqrt, abs
+import warnings
+from timeit import default_timer as timer
+
+import numpy as np
+import pandas as pd
+from astropy.utils.data import get_pkg_data_filename
+
+from paths import ScanPaths
+from video.scripts.moviemaker import MovieMaker
+
 warnings.filterwarnings("ignore")
 
 parser = argparse.ArgumentParser("Make movie from fits file.")
-parser.add_argument('-d', '--downloading', type=int, help='Download your own data')
-parser.add_argument('-csv', '--csvfile', help='Csv file with outliers with RA and DEC in degrees')
-parser.add_argument('-fr', '--framerate', type=int, help='Frame rate of your video')
-parser.add_argument('-fi', '--fits', type=str, help='Fits file to use')
+parser.add_argument("-d", "--downloading", type=int, help="Download your own data")
+parser.add_argument("-csv", "--csvfile", help="Csv file with outliers with RA and DEC in degrees")
+parser.add_argument("-fr", "--framerate", type=int, help="Frame rate of your video")
+parser.add_argument("-zs", "--zoomsize", type=float, help="Size in deg of the zoomed image")
+parser.add_argument("-dr", "--degrate", type=float, help="Amount of degrees traversed each second")
+parser.add_argument("-fi", "--fits", type=str, help="Fits file to use")
+parser.add_argument("-sc", "--scan", type=str, help="Scanning path type")
 args = parser.parse_args()
 
+
 def distance(obj_1, obj_2):
-    return sqrt((obj_1[0]-obj_2[0])**2+4*(obj_1[1]-obj_2[1])**2)
+    return np.sqrt((obj_1[0] - obj_2[0]) ** 2 + 4 * (obj_1[1] - obj_2[1]) ** 2)
 
-def isNaN(a):
-    return a!=a
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     start = timer()
 
-    if args.framerate: FRAMERATE = args.framerate
-    else: FRAMERATE = 20
+    if args.framerate:
+        FRAMERATE = args.framerate
+    else:
+        FRAMERATE = 20
+
+    if args.zoomsize:
+        ZOOMSIZE = args.zoomsize
+    else:
+        ZOOMSIZE = 1.4
+
+    if args.degrate:
+        DEGRATE = args.degrate
+    else:
+        DEGRATE = 1.0
 
     if args.downloading == 1:
-        download = input('Paste here your url where to find the fits file: ')
+        download = input("Paste here your url where to find the fits file: ")
         fits_download = True
-        Movie = MovieMaker(fits_download=True,
-                           imsize=0.4,#defaul imsize
-                            framerate=FRAMERATE)
+        Movie = MovieMaker(fits_download=True, imsize=0.4, framerate=FRAMERATE)  # default imsize
     else:
         fits_download = False
         if args.fits:
             file = args.fits
         else:
-            file = 'fits/elias.fits'
+            file = "fits/elias.fits"
         try:
-            fitsfile=get_pkg_data_filename(file)
-        except:
-            fitsfile=file
-        Movie = MovieMaker(fits_file=fitsfile,
-                           imsize=0.4,#default imsize
-                            framerate=FRAMERATE, zoom_effect=False)
+            fitsfile = get_pkg_data_filename(file)
+        except BaseException:
+            fitsfile = file
+        Movie = MovieMaker(fits_file=fitsfile, imsize=0.4, framerate=FRAMERATE, zoom_effect=False)  # default imsize
 
-    if args.csvfile:#go through all objects in csv file
-        df = pd.read_csv(args.csvfile)[['RA', 'DEC', 'imsize']]
+    if args.csvfile:  # go through all objects in csv file
+        df = pd.read_csv(args.csvfile)[["RA", "DEC", "imsize"]]
 
-        start_coord = Movie.wcs.pixel_to_world(Movie.image_data.shape[1]/2, Movie.image_data.shape[0]/2)
+        start_coord = Movie.wcs.pixel_to_world(Movie.image_data.shape[1] / 2, Movie.image_data.shape[0] / 2)
         start_dec = start_coord.dec.degree
         start_ra = start_coord.ra.degree
 
-        Movie.zoom(N_frames=int(5*Movie.framerate), first_time=True)
-        for n in range(len(df)-1):#stack multiple sources
+        Movie.zoom(N_frames=int(5 * Movie.framerate), first_time=True)
+        for n in range(len(df) - 1):  # stack multiple sources
             if n > 0:
-                dist = distance([last_RA, last_DEC], [df['RA'].values[n], df['DEC'].values[n]])
-                move_to_frames = max(int(4*dist*Movie.framerate), 2)
+                dist = distance([last_RA, last_DEC], [df["RA"].values[n], df["DEC"].values[n]])
+                move_to_frames = np.max(int(4 * dist * Movie.framerate), 2)
             else:
-                dist = distance([start_ra, start_dec], [df['RA'].values[n], df['DEC'].values[n]])
-                move_to_frames = max(int(4*dist*Movie.framerate), 2)
-            Movie.move_to(N_frames=move_to_frames, ra=df['RA'].values[n], dec=df['DEC'].values[n])
-            zoom_frames = max(int(0.1 * Movie.framerate * Movie.imsize / df['imsize'].values[n]), 2)
-            Movie.zoom(N_frames=zoom_frames, imsize_out=df['imsize'].values[n])
-            if n<len(df)-1 and df['imsize'].values[n+1]>df['imsize'].values[n]:
-                im_out = max(df['imsize'].values[n+1]+0.3, 0.3)
+                dist = distance([start_ra, start_dec], [df["RA"].values[n], df["DEC"].values[n]])
+                move_to_frames = np.max(int(4 * dist * Movie.framerate), 2)
+            Movie.move_to(N_frames=move_to_frames, ra=df["RA"].values[n], dec=df["DEC"].values[n])
+            zoom_frames = np.max(int(0.1 * Movie.framerate * Movie.imsize / df["imsize"].values[n]), 2)
+            Movie.zoom(N_frames=zoom_frames, imsize_out=df["imsize"].values[n])
+            if n < len(df) - 1 and df["imsize"].values[n + 1] > df["imsize"].values[n]:
+                im_out = np.max(df["imsize"].values[n + 1] + 0.3, 0.3)
             else:
-                im_out = max(df['imsize'].values[n] + 0.3, 0.3)
-            Movie.zoom(N_frames=max(zoom_frames//5, 1), imsize_out=im_out)
-            last_RA, last_DEC = df['RA'].values[n], df['DEC'].values[n]
-        move_to_frames = max(int(4*Movie.framerate * distance([start_ra, start_dec], [last_RA, last_DEC])), 2)
+                im_out = np.max(df["imsize"].values[n] + 0.3, 0.3)
+            Movie.zoom(N_frames=np.max(zoom_frames // 5, 1), imsize_out=im_out)
+            last_RA, last_DEC = df["RA"].values[n], df["DEC"].values[n]
+        move_to_frames = np.max(int(4 * Movie.framerate * distance([start_ra, start_dec], [last_RA, last_DEC])), 2)
         Movie.move_to(N_frames=move_to_frames, ra=start_ra, dec=start_dec)
-        Movie.zoom(N_frames=int(5*Movie.framerate), imsize_out=2)
+        Movie.zoom(N_frames=int(5 * Movie.framerate), imsize_out=2)
         Movie.record()
 
         end = timer()
-        print(f'MovieMaker took {int(end - start)} seconds')
+        print(f"MovieMaker took {int(end - start)} seconds")
 
-    else:#go through whole field
-        fits_header = Movie.wcs.to_header()
+    else:  # Go through whole field
+        full_size = Movie.image_data.shape[0] * np.max(Movie.wcs.pixel_scale_matrix)
 
-        number_of_steps = int(fits_header['CRPIX1']*2/3500)
-        if number_of_steps%2==0:
-            number_of_steps+=1 # make number of steps uneven to come back in the center
+        Path = ScanPaths(movie_obj=Movie, zoom_size=ZOOMSIZE, deg_per_sec=DEGRATE)
 
-        # clean_image = Movie.image_data[~isnan(Movie.image_data).all(axis=1),:]
-        # clean_image = clean_image[:,~isnan(clean_image).all(axis=0)]
-        pix_x_size = fits_header['CRPIX1']*2 #pixel x axis size
-        pix_y_size = fits_header['CRPIX2']*2 #pixel y axis size
-        # x_cut = pix_x_size-clean_image.shape[0] #how much cut x
-        # y_cut = pix_y_size-clean_image.shape[1] #how much cut y
-        step_size_x = int(pix_x_size/number_of_steps)
-        step_size_y = int(pix_y_size/number_of_steps)
-        start_pix_x = int((pix_x_size)/(number_of_steps*2))
-        start_pix_y = int(pix_y_size*((number_of_steps*2-1)/(number_of_steps*2)))
+        if args.scan == "horizontal":
+            positions, n_frames = Path.horizontal_scan()
+        elif args.scan == "spiral":
+            positions, n_frames = Path.spiral_scan()
+        else:
+            print("No preferred scanning path chosen. Defaulting to horizontal scan.")
+            positions, n_frames = Path.horizontal_scan()
 
-        pos_x = start_pix_x
-        pos_y = start_pix_y
-        positions = [[start_pix_x, start_pix_y]]
-        for i in range(number_of_steps-1):
-            pos_x+=step_size_x
-            positions.append([pos_x, pos_y])
+        print(f"Moving to positions {positions} in {n_frames} frames.")
 
-        for i in range(1,number_of_steps)[::-1]:
-            for j in range(i):
-                pos_y = pos_y + ((-1)**(i+number_of_steps))*step_size_y
-                positions.append([pos_x, pos_y])
-            for j in range(i):
-                pos_x = pos_x + ((-1)**(i+number_of_steps))*step_size_x
-                positions.append([pos_x, pos_y])
-
-        try:
-            positions = [(p.ra.degree, p.dec.degree) for p in [Movie.wcs.pixel_to_world(position[0], position[1])
-                                                               for position in positions
-                                                               if not isNaN(Movie.image_data[position[0], position[1]])]]
-        except:
-            positions = [(p.ra.degree, p.dec.degree) for p in [Movie.wcs.pixel_to_world(position[0], position[1])
-                                                               for position in positions]]
-
-        Movie.imsize = 2*abs(fits_header['CDELT1']*fits_header['CRPIX1']/number_of_steps)
-        Movie.zoom(N_frames=int(3*Movie.framerate), first_time=True)
-        start_coord = Movie.wcs.pixel_to_world(Movie.image_data.shape[0] / 2, Movie.image_data.shape[0] / 2)
-        start_dec = start_coord.dec.degree
-        start_ra = start_coord.ra.degree
-        for n, position in enumerate(positions):
-            if n==0:
-                dist = distance([start_ra, start_dec], [position[0], position[1]])
-            else:
-                dist = distance([position[0], position[1]], [positions[n-1][0], positions[n-1][1]])
-            move_to_frames = max(int(4*dist*Movie.framerate), 2)
-            Movie.move_to(N_frames=move_to_frames, ra=position[0], dec=position[1])
-        Movie.zoom(N_frames=int(3*Movie.framerate), imsize_out=3)
+        Movie.imsize = ZOOMSIZE
+        Movie.zoom(N_frames=FRAMERATE, first_time=True, full_im=True)  # Start with zoom in
+        for n, pos in enumerate(positions):  # Move through path
+            Movie.move_to(N_frames=n_frames[n], ra=pos[0], dec=pos[1])
+        Movie.zoom(N_frames=FRAMERATE, imsize_out=full_size)  # End with zoom out
         Movie.record()
+
+        """
+        Could be added later as well: a video starting with a zoom in and ending in a zoom out could
+        reuse the zoom in frames for the zoom out which should save computation time.
+        """

--- a/make_poster.py
+++ b/make_poster.py
@@ -1,45 +1,55 @@
-from poster.scripts.imaging import ImagingLofar
-from astropy.utils.data import get_pkg_data_filename
-import os
-import pandas as pd
 import argparse
+import os
+
+import pandas as pd
+from astropy.utils.data import get_pkg_data_filename
+
+from poster.scripts.imaging import ImagingLofar
 
 parser = argparse.ArgumentParser("Make poster from fits file.")
-parser.add_argument('-d', '--downloading', type=int, help='download your own data')
-parser.add_argument('-csv', '--csvfile', help='csv file with outliers with RA and DEC in degrees', default='catalogue/catalogue_lockman.csv')
-parser.add_argument('-fi', '--fits', type=str, help='fits file to use')
+parser.add_argument("-d", "--downloading", type=int, help="download your own data")
+parser.add_argument(
+    "-csv",
+    "--csvfile",
+    help="csv file with outliers with RA and DEC in degrees",
+    default="catalogue/catalogue_lockman.csv",
+)
+parser.add_argument("-fi", "--fits", type=str, help="fits file to use")
 args = parser.parse_args()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if args.csvfile:
-        df = pd.read_csv(args.csvfile)[['RA', 'DEC', 'size_x', 'size_y']].to_numpy()[0:12]
+        df = pd.read_csv(args.csvfile)[["RA", "DEC", "size_x", "size_y"]].to_numpy()[0:12]
     else:
-        df = pd.read_csv(os.listdir('catalogue')[0])
+        df = pd.read_csv(os.listdir("catalogue")[0])
 
     if args.downloading == 1:
-        download = input('Paste here your url where to find the fits file: ')
-        fits_download=True
+        download = input("Paste here your url where to find the fits file: ")
+        fits_download = True
         Image = ImagingLofar(fits_download=True)
     else:
         fits_download = False
         if args.fits:
             file = args.fits
         else:
-            file = 'fits/lockman_hole.fits'
+            file = "fits/lockman_hole.fits"
         Image = ImagingLofar(fits_file=get_pkg_data_filename(file))
 
-    Image.imaging(image_name='main.png', save=True, dpi=3000)
+    Image.imaging(image_name="main.png", save=True, dpi=3000)
 
     for n, position in enumerate(df):
-        if position[3]==position[3]:
-            Image.image_cutout(pos=tuple(position[0:2]), size=tuple(position[2:4]), image_name=f'cutout_{n}.png',
-                               save=True, cmap='jet')
+        if position[3] == position[3]:
+            Image.image_cutout(
+                pos=tuple(position[0:2]), size=tuple(position[2:4]), image_name=f"cutout_{n}.png", save=True, cmap="jet"
+            )
         else:
-            Image.image_cutout(pos=tuple(position[0:2]), image_name=f'cutout_{n}.png', save=True, cmap='jet')
+            Image.image_cutout(pos=tuple(position[0:2]), image_name=f"cutout_{n}.png", save=True, cmap="jet")
 
     try:
-        os.system('python poster/scripts/make_pdf.py')
-    except:
-        print("You need Scribus version 1.5 or higher to convert the .sla file to .pdf \n"
-              "see for example: "
-              "https://sourceforge.net/projects/scribus/files/scribus-devel/1.5.5/scribus-1.5.5-windows-x64.exe/download")
+        os.system("python poster/scripts/make_pdf.py")
+    except BaseException:
+        print(
+            "You need Scribus version 1.5 or higher to convert the .sla file to .pdf \n"
+            "see for example: "
+            "https://sourceforge.net/projects/scribus/files/scribus-devel/1.5.5/scribus-1.5.5-windows-x64.exe/download"
+        )

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,173 @@
+from math import ceil
+
+import numpy as np
+
+
+def isNaN(a):
+    return a != a
+
+
+class ScanPaths:
+    """
+    ScanPaths is an accessible way to make scanning paths over an image.
+    """
+
+    def __init__(self, movie_obj=None, zoom_size: float = None, deg_per_sec: float = None):
+        """
+        :param movie_obj: instance of MovieMaker class
+        :param zoom_size: size in deg to which the image is zoomed, default 1.4 deg
+        """
+        self.Movie = movie_obj
+        self.zoom_size = zoom_size
+        self.deg_per_sec = deg_per_sec
+        self.fits_header = self.Movie.wcs.to_header()
+        self.central_ra = self.fits_header["CRVAL1"]
+        self.central_dec = self.fits_header["CRVAL2"]
+        self.pix_x_size = int(self.fits_header["CRPIX1"] * 2)  # x axis size in pixels
+        self.pix_y_size = int(self.fits_header["CRPIX2"] * 2)  # y axis size in pixels
+        self.deg_x_size = np.abs(self.pix_x_size * self.fits_header["CDELT1"])  # x axis size in degrees
+        self.deg_y_size = np.abs(self.pix_y_size * self.fits_header["CDELT2"])  # y axis size in degrees
+        self.zoom_factor_x = self.deg_x_size / zoom_size  # For now assumed to be equal to zoom_factor_y
+
+        # These pixel positions give a reference frame from which to build the paths:
+        self.left_x = int(self.pix_x_size / (self.zoom_factor_x * 2))
+        self.right_x = int(self.pix_x_size - self.left_x)
+        self.upper_y = int(self.pix_y_size * ((self.zoom_factor_x * 2 - 1) / (self.zoom_factor_x * 2)))
+        self.lower_y = int(self.pix_y_size - self.upper_y)
+
+    def move_upper_left(self, positions):
+        positions.append([self.left_x, self.upper_y])
+        return positions
+
+    def move_center(self, positions):
+        positions.append([int(self.pix_x_size / 2), int(self.pix_y_size / 2)])
+        return positions
+
+    def move_full_left(self, positions):
+        current_pos = positions[-1]
+        positions.append([self.left_x, current_pos[1]])
+        return positions
+
+    def move_full_right(self, positions):
+        current_pos = positions[-1]
+        positions.append([self.right_x, current_pos[1]])
+        return positions
+
+    def move_full_down(self, positions):
+        current_pos = positions[-1]
+        positions.append([current_pos[0], self.lower_y])
+        return positions
+
+    def move_full_up(self, positions):
+        current_pos = positions[-1]
+        positions.append([current_pos[0], self.upper_y])
+        return positions
+
+    def vertical_shift(self, positions, shift_size):
+        """Negative shift_size corresponds to a downward shift."""
+        current_pos = positions[-1]
+        positions.append([current_pos[0], current_pos[1] + shift_size])
+        return positions
+
+    def horizontal_shift(self, positions, shift_size):
+        """Negative shift_size corresponds to a leftward shift."""
+        current_pos = positions[-1]
+        positions.append([current_pos[0] + shift_size, current_pos[1]])
+        return positions
+
+    def pix2deg(self, positions):
+        try:
+            positions = [
+                (p.ra.degree, p.dec.degree)
+                for p in [
+                    self.Movie.wcs.pixel_to_world(position[0], position[1])
+                    for position in positions
+                    if not isNaN(self.Movie.image_data[position[0], position[1]])
+                ]
+            ]
+        except BaseException:
+            positions = [
+                (p.ra.degree, p.dec.degree)
+                for p in [self.Movie.wcs.pixel_to_world(position[0], position[1]) for position in positions]
+            ]
+        return positions
+
+    def frames_per_move(self, deg_positions):
+        # Include central starting position to calculate shift distance of first move
+        start_pos = np.array([self.central_ra, self.central_dec])
+        full_deg_positions = np.concatenate(([start_pos], deg_positions))
+
+        # Calculate distance in degrees of each move
+        ra_diff = np.abs(np.diff(full_deg_positions[:, 0]))
+        ra_diff_min = np.where(ra_diff > 180, np.abs(ra_diff - 360), ra_diff)  # Corrects for crossing zero meridian
+        dec_diff = np.abs(np.diff(full_deg_positions[:, 1]))
+        dist = np.sqrt(ra_diff_min**2 + dec_diff**2)
+
+        dist2frames = dist / self.deg_per_sec * self.Movie.framerate
+        return np.maximum(dist2frames.astype(int), 2)
+
+    def horizontal_scan(self):
+        """Makes a horizontal scanning path over the image, starting from the upper left corner."""
+        n_scans = int(ceil(self.deg_y_size / self.zoom_size))  # Amount of horizontally moving scans
+        vertical_shift_size = int(self.pix_y_size / n_scans)
+
+        positions = []
+        self.move_upper_left(positions)  # Move to start position
+        for i in range(n_scans):
+            if i % 2 == 0:
+                if i != n_scans - 1:  # The last move does not contain a shift downward
+                    positions = self.move_full_right(positions)
+                    positions = self.vertical_shift(positions, -vertical_shift_size)
+                else:
+                    positions = self.move_full_right(positions)
+            else:
+                if i != n_scans - 1:
+                    positions = self.move_full_left(positions)
+                    positions = self.vertical_shift(positions, -vertical_shift_size)
+                else:
+                    positions = self.move_full_left(positions)
+        positions = self.move_center(positions)
+
+        deg_positions = self.pix2deg(positions)
+        n_frames = self.frames_per_move(deg_positions)
+        return np.array(deg_positions), n_frames
+
+    def spiral_scan(self):
+        """Makes a spiralling scanning path over the image, starting from the upper left corner
+        and going horizontally to the right."""
+        n_scans = int(ceil(self.deg_y_size / self.zoom_size))  # Amount of horizontally moving scans
+        shift_size = int(self.pix_y_size / n_scans)  # Again, assuming square image
+        n_iterations = ceil(n_scans / 2 - 1)  # To account for performing multiple moves each iteration
+        positions = []
+        self.move_upper_left(positions)  # Move to start position
+        for i in range(n_iterations + 1):
+            if i == n_iterations:  # The last iteration is different for even and odd n_scans
+                if i % 2 == 0:
+                    positions = self.move_full_right(positions)
+                    positions[-1][0] -= i * shift_size
+
+                    positions = self.move_full_down(positions)
+                    positions[-1][1] += i * shift_size
+
+                    positions = self.move_full_left(positions)
+                    positions[-1][0] += i * shift_size
+
+                    positions = self.move_center(positions)
+                else:
+                    positions = self.move_full_right(positions)
+                    positions[-1][0] -= i * shift_size
+            else:
+                positions = self.move_full_right(positions)
+                positions[-1][0] -= i * shift_size
+
+                positions = self.move_full_down(positions)
+                positions[-1][1] += i * shift_size
+
+                positions = self.move_full_left(positions)
+                positions[-1][0] += i * shift_size
+
+                positions = self.move_full_up(positions)
+                positions[-1][1] -= (i + 1) * shift_size
+        deg_positions = self.pix2deg(positions)
+        n_frames = self.frames_per_move(deg_positions)
+        return np.array(deg_positions), n_frames

--- a/poster/scripts/imaging.py
+++ b/poster/scripts/imaging.py
@@ -1,23 +1,35 @@
-import matplotlib.pyplot as plt
-from astropy.wcs import WCS
-from astropy.io import fits
-from astropy.utils.data import download_file
-from astropy.nddata import Cutout2D
-import astropy.units as u
-from astropy import wcs
-from astropy import coordinates
-import numpy as np
 import os
-from scipy.ndimage import gaussian_filter
-from matplotlib.colors import LogNorm, SymLogNorm
 import warnings
+
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import coordinates
+from astropy import wcs
+from astropy.io import fits
+from astropy.nddata import Cutout2D
+from astropy.utils.data import download_file
+from astropy.wcs import WCS
+from matplotlib.colors import LogNorm, SymLogNorm
+from scipy.ndimage import gaussian_filter
+
 warnings.filterwarnings("ignore")
 
-__all__ = ['ImagingLofar']
+__all__ = ["ImagingLofar"]
+
 
 class ImagingLofar:
-    def __init__(self, fits_file=None, fits_download: bool=False, vmin: float = None, vmax: float = None,
-                 image_directory: str='poster/images', verbose: bool = True, zoom_effect: bool = True, interactive: bool = False):
+    def __init__(
+        self,
+        fits_file=None,
+        fits_download: bool = False,
+        vmin: float = None,
+        vmax: float = None,
+        image_directory: str = "poster/images",
+        verbose: bool = True,
+        zoom_effect: bool = True,
+        interactive: bool = False,
+    ):
         """
         Make LOFAR images (also applicable on other telescope surveys)
         ------------------------------------------------------------
@@ -32,22 +44,24 @@ class ImagingLofar:
         self.verbose = verbose
         self.zoom_effect = zoom_effect
         if self.verbose:
-            print(f"Started imaging {fits_file.split('/')[-1].replace('.fits','').replace('_',' ').replace('.',' ').title()}...")
+            print(
+                f"Started imaging {fits_file.split('/')[-1].replace('.fits', '').replace('_', ' ').replace('.', ' ').title()}..."
+            )
         if fits_download:
-            link = input('Past here your fits link: \n')
+            link = input("Past here your fits link: \n")
             self.hdu = download_file(link, cache=True)
         else:
             self.hdu = fits.open(fits_file)[0]
-        self.image_data=self.hdu.data
-        while len(self.image_data.shape)!=2:
-            self.image_data=self.image_data[0]
+        self.image_data = self.hdu.data
+        while len(self.image_data.shape) != 2:
+            self.image_data = self.image_data[0]
         self.wcs = WCS(self.hdu.header, naxis=2)
         if vmin is None:
             self.vmin = np.nanstd(self.image_data)
         else:
             self.vmin = vmin
         if vmax is None:
-            self.vmax = np.nanstd(self.image_data)*20
+            self.vmax = np.nanstd(self.image_data) * 20
         else:
             self.vmax = vmax
         self.image_directory = image_directory
@@ -61,21 +75,29 @@ class ImagingLofar:
         else:
             print(f"Successfully created the directory: '{self.image_directory}'")
 
-        #Transfer function
+        # Transfer function
         if not interactive:
-            if 'cutout' in self.fits_file:
-                self.image_data = gaussian_filter(self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin), sigma=3)
-            elif 'ILTJ' in self.fits_file:
-                self.image_data = gaussian_filter(self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin/1.5), sigma=4)
+            if "cutout" in self.fits_file:
+                self.image_data = gaussian_filter(
+                    self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin), sigma=3
+                )
+            elif "ILTJ" in self.fits_file:
+                self.image_data = gaussian_filter(
+                    self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin / 1.5), sigma=4
+                )
             else:
                 if self.zoom_effect:
-                    self.image_data = gaussian_filter(self.tonemap(image_data=self.image_data, b=0.5, threshold=0), sigma=2)
+                    self.image_data = gaussian_filter(
+                        self.tonemap(image_data=self.image_data, b=0.5, threshold=0), sigma=2
+                    )
                 else:
-                    self.image_data = gaussian_filter(self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin/100), sigma=1)
+                    self.image_data = gaussian_filter(
+                        self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin / 100), sigma=1
+                    )
         else:
             self.image_data = gaussian_filter(
-                self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin / 100), sigma=1)
-
+                self.tonemap(image_data=self.image_data, b=0.25, threshold=self.vmin / 100), sigma=1
+            )
 
     def tonemap(self, image_data=None, b: float = 0.25, threshold: float = None):
         """
@@ -91,15 +113,32 @@ class ImagingLofar:
             threshold = 0
         data_pos = np.where(image_data > threshold, image_data, np.nan)
         data_res = np.where(image_data < threshold, image_data, np.nan)
-        data_pos_tm = (np.nanmax(data_pos) * 0.01 / np.log10(np.nanmax(data_pos) + 1)) * (np.log10(data_pos + 1)) / (
-            np.log10(2 + ((data_pos / np.nanmax(data_pos)) ** (np.log10(b) / np.log10(0.5))) * 8))
-        data_res_tm = (np.nanmax(data_res) * 0.01/ np.log10(np.nanmax(data_res) + 1)) * (np.log10(data_res + 1)) / (
-            np.log10(2 + ((data_res / np.nanmax(data_res)) ** (np.log10(b) / np.log10(0.5))) * 8))
-        data_tm = np.where(image_data > threshold, np.sqrt(data_pos_tm), -1*np.sqrt(np.abs(data_res_tm)))
+        data_pos_tm = (
+            (np.nanmax(data_pos) * 0.01 / np.log10(np.nanmax(data_pos) + 1))
+            * (np.log10(data_pos + 1))
+            / (np.log10(2 + ((data_pos / np.nanmax(data_pos)) ** (np.log10(b) / np.log10(0.5))) * 8))
+        )
+        data_res_tm = (
+            (np.nanmax(data_res) * 0.01 / np.log10(np.nanmax(data_res) + 1))
+            * (np.log10(data_res + 1))
+            / (np.log10(2 + ((data_res / np.nanmax(data_res)) ** (np.log10(b) / np.log10(0.5))) * 8))
+        )
+        data_tm = np.where(image_data > threshold, np.sqrt(data_pos_tm), -1 * np.sqrt(np.abs(data_res_tm)))
         return data_tm
 
-    def imaging(self, image_data=None, wcs=None, image_name: str = 'Nameless', dpi: int = None, save: bool = True,
-                cmap: str = 'CMRmap', text: str = None, imsize: float = None, ra=None, dec=None):
+    def imaging(
+        self,
+        image_data=None,
+        wcs=None,
+        image_name: str = "Nameless",
+        dpi: int = None,
+        save: bool = True,
+        cmap: str = "CMRmap",
+        text: str = None,
+        imsize: float = None,
+        ra=None,
+        dec=None,
+    ):
         """
         Imaging of your data.
         ------------------------------------------------------------
@@ -118,65 +157,78 @@ class ImagingLofar:
         if image_data is None:
             image_data = self.image_data
         if wcs is None:
-            wcs=self.wcs
+            wcs = self.wcs
         if dpi is None:
             w = 16
-            h = image_data.shape[1]/image_data.shape[0]*9
-            dpi = image_data.shape[0]/10
+            h = image_data.shape[1] / image_data.shape[0] * 9
+            dpi = image_data.shape[0] / 10
         else:
-            h=9
-            w=16
+            h = 9
+            w = 16
         plt.figure(figsize=(h, w))
         plt.subplot(projection=wcs)
         if imsize is None:
-            imsize=1
-        if 'cutout' in self.fits_file:
-            plt.imshow(image_data, origin='lower', cmap=cmap, vmin=self.vmin*2)
+            imsize = 1
+        if "cutout" in self.fits_file:
+            plt.imshow(image_data, origin="lower", cmap=cmap, vmin=self.vmin * 2)
         else:
-            #HIGH RES VIDEO:
+            # HIGH RES VIDEO:
             if self.zoom_effect:
                 vmax = self.vmax
-                vmin = min((2/max(imsize,0.2))*(self.vmin/100), self.vmax/20)
-                if imsize<1:
-                    vmax/=max(imsize, 0.2)
-                if imsize<0.1:
-                    vmin+=imsize/100*(0.1/imsize)**1.35
-                image_data=gaussian_filter(image_data, sigma=2)
+                vmin = min((2 / max(imsize, 0.2)) * (self.vmin / 100), self.vmax / 20)
+                if imsize < 1:
+                    vmax /= max(imsize, 0.2)
+                if imsize < 0.1:
+                    vmin += imsize / 100 * (0.1 / imsize) ** 1.35
+                image_data = gaussian_filter(image_data, sigma=2)
 
-                plt.imshow(image_data,
-                           norm=SymLogNorm(linthresh=vmin*20, vmin=self.vmin/1.4, vmax=vmax), origin='lower', cmap=cmap)
+                plt.imshow(
+                    image_data,
+                    norm=SymLogNorm(linthresh=vmin * 20, vmin=self.vmin / 1.4, vmax=vmax),
+                    origin="lower",
+                    cmap=cmap,
+                )
             else:
-                plt.imshow(np.clip(image_data, a_min=None, a_max=self.vmax),
-                           norm=LogNorm(vmin=self.vmin / 1.4, vmax=self.vmax), origin='lower', cmap=cmap)
+                plt.imshow(
+                    np.clip(image_data, a_min=None, a_max=self.vmax),
+                    norm=LogNorm(vmin=self.vmin / 1.4, vmax=self.vmax),
+                    origin="lower",
+                    cmap=cmap,
+                )
         if text:
             plt.annotate(
-                s=text,
+                text=text,
                 xy=(0, 0),
                 xytext=(0, 0),
-                va='top',
-                ha='left',
+                va="top",
+                ha="left",
                 fontsize=20,
-                bbox=dict(facecolor='white', alpha=1),
+                bbox=dict(facecolor="white", alpha=1),
             )
-        elif ra and dec and imsize>0.1:
+        elif ra and dec and imsize > 0.1:
             plt.annotate(
-                s=f'RA: {round(ra, 5)}\nDEC: {round(dec, 5)}',
+                text=f"RA: {round(ra, 5)}\nDEC: {round(dec, 5)}",
                 xy=(0, 0),
                 xytext=(0, 0),
-                va='top',
-                ha='left',
+                va="top",
+                ha="left",
                 fontsize=10,
-                bbox=dict(facecolor='white', alpha=0.7),
+                bbox=dict(facecolor="white", alpha=0.7),
             )
-        plt.xlabel('Galactic Longitude')
-        plt.ylabel('Galactic Latitude')
+        plt.xlabel("Galactic Longitude")
+        plt.ylabel("Galactic Latitude")
         plt.grid(False)
-        plt.axis('off')
+        plt.axis("off")
         plt.tight_layout()
         plt.subplots_adjust(left=0.0, bottom=0.0, top=1.0, right=1.0)
         if save:
-            plt.savefig(f'{self.image_directory}/{image_name}', bbox_inches='tight', dpi=dpi, facecolor='black',
-                        edgecolor='black')
+            plt.savefig(
+                f"{self.image_directory}/{image_name}",
+                bbox_inches="tight",
+                dpi=dpi,
+                facecolor="black",
+                edgecolor="black",
+            )
             plt.close()
         else:
             plt.show()
@@ -195,13 +247,7 @@ class ImagingLofar:
         """
         if self.verbose:
             print(f"We are now making a cutout from your image.")
-        cutout = Cutout2D(
-            data=self.image_data,
-            position=pos,
-            size=size,
-            wcs=self.wcs,
-            mode='partial'
-        )
+        cutout = Cutout2D(data=self.image_data, position=pos, size=size, wcs=self.wcs, mode="partial")
         if self.verbose:
             print(f"Cutout finished")
         return cutout.data, cutout.wcs
@@ -214,14 +260,23 @@ class ImagingLofar:
         :param dec: Declination (degrees)
         :return: Pixel of position
         """
-        position = coordinates.SkyCoord(ra, dec,
-                                        frame=wcs.utils.wcs_to_celestial_frame(self.wcs).name,
-                                        unit=(u.degree, u.degree))
+        position = coordinates.SkyCoord(
+            ra, dec, frame=wcs.utils.wcs_to_celestial_frame(self.wcs).name, unit=(u.degree, u.degree)
+        )
         position = np.array(position.to_pixel(self.wcs))
         return position
 
-    def image_cutout(self, pos: tuple = None, size: tuple = None, dpi: float = 1000, image_name: str = None,
-                     save: bool = True, cmap: str = 'CMRmap', text: str = None, imsize: float = None):
+    def image_cutout(
+        self,
+        pos: tuple = None,
+        size: tuple = None,
+        dpi: float = 1000,
+        image_name: str = None,
+        save: bool = True,
+        cmap: str = "CMRmap",
+        text: str = None,
+        imsize: float = None,
+    ):
         """
         Make image cutout and make image
         ------------------------------------------------------------
@@ -237,17 +292,33 @@ class ImagingLofar:
         ra, dec = pos
         pix_x, pix_y = self.to_pixel(ra, dec)
         if size:
-            if size[0]<2 and size[0]<2:
-                size = (np.int(imsize/np.max(self.wcs.pixel_scale_matrix)), np.int(imsize/np.max(self.wcs.pixel_scale_matrix)))
+            if size[0] < 2 and size[0] < 2:
+                size = (
+                    np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                    np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                )
         else:
-            size = (np.int(imsize/np.max(self.wcs.pixel_scale_matrix)), np.int(imsize/np.max(self.wcs.pixel_scale_matrix)))
-        image_data, wcs = self.make_cutout((pix_x, pix_y), size)
+            size = (
+                np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+            )
+        image_data, wcs = self.make_cutout((int(pix_x), int(pix_y)), size)
         if self.verbose:
-            print(f"Let's now image '{image_name.replace('_',' ').replace('.png','').replace('.',' ').title()}'")
-        if size[0]<dpi:
-            dpi=size[0]
-        self.imaging(image_data=image_data, wcs=wcs, image_name=image_name, dpi=dpi,
-                     save=save, cmap=cmap, text=text, imsize=imsize, ra=ra, dec=dec)
+            print(f"Let's now image '{image_name.replace('_', ' ').replace('.png', '').replace('.', ' ').title()}'")
+        if size[0] < dpi:
+            dpi = size[0]
+        self.imaging(
+            image_data=image_data,
+            wcs=wcs,
+            image_name=image_name,
+            dpi=dpi,
+            save=save,
+            cmap=cmap,
+            text=text,
+            imsize=imsize,
+            ra=ra,
+            dec=dec,
+        )
         return self
 
     def make_fits(self, pos: tuple = None, size: tuple = (1000, 1000), filename: str = None, imsize: float = None):
@@ -262,15 +333,22 @@ class ImagingLofar:
         ra, dec = pos
         pix_x, pix_y = self.to_pixel(ra, dec)
         if size:
-            if size[0]<2 and size[0]<2:
-                size = (np.int(imsize/np.max(self.wcs.pixel_scale_matrix)), np.int(imsize/np.max(self.wcs.pixel_scale_matrix)))
+            if size[0] < 2 and size[0] < 2:
+                size = (
+                    np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                    np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                )
         else:
-            size = (np.int(imsize/np.max(self.wcs.pixel_scale_matrix)), np.int(imsize/np.max(self.wcs.pixel_scale_matrix)))
+            size = (
+                np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+                np.int(imsize / np.max(self.wcs.pixel_scale_matrix)),
+            )
         image_data, wcs = self.make_cutout((pix_x, pix_y), size)
         self.hdu.data = image_data
         self.hdu.header.update(wcs.to_header())
-        self.hdu.writeto(f'{self.image_directory}/{filename}', overwrite=True)
+        self.hdu.writeto(f"{self.image_directory}/{filename}", overwrite=True)
         return self
 
-if __name__ == '__main__':
-    print('Cannot call script directly.')
+
+if __name__ == "__main__":
+    print("Cannot call script directly.")

--- a/poster/scripts/make_pdf.py
+++ b/poster/scripts/make_pdf.py
@@ -1,24 +1,26 @@
-#https://opensource.com/sites/default/files/ebooks/pythonscriptingwithscribus.pdf
+# https://opensource.com/sites/default/files/ebooks/pythonscriptingwithscribus.pdf
 
 import fileinput
 import os
 
-os.system('yes | cp -rf poster/templates/template.sla poster/template.sla')
+os.system("yes | cp -rf poster/templates/template.sla poster/template.sla")
 
-your_title=input("Write here your title (or press enter):\n")
-your_text=input("Write here your description of your poster (or press enter):\n")
-
-with fileinput.FileInput("poster/template.sla", inplace=True) as file:
-    for line in file:
-        print(line.replace('template_text', your_text), end='')
+your_title = input("Write here your title (or press enter):\n")
+your_text = input("Write here your description of your poster (or press enter):\n")
 
 with fileinput.FileInput("poster/template.sla", inplace=True) as file:
     for line in file:
-        print(line.replace('title_template', your_title), end='')
+        print(line.replace("template_text", your_text), end="")
+
+with fileinput.FileInput("poster/template.sla", inplace=True) as file:
+    for line in file:
+        print(line.replace("title_template", your_title), end="")
 
 try:
-    os.system('scribus --python-script poster/scripts/sla_to_pdf.py')
-except:
-    print("You need Scribus version 1.5 or higher to convert the .sla file to .pdf \n"
-          "see for example: "
-          "https://sourceforge.net/projects/scribus/files/scribus-devel/1.5.5/scribus-1.5.5-windows-x64.exe/download")
+    os.system("scribus --python-script poster/scripts/sla_to_pdf.py")
+except BaseException:
+    print(
+        "You need Scribus version 1.5 or higher to convert the .sla file to .pdf \n"
+        "see for example: "
+        "https://sourceforge.net/projects/scribus/files/scribus-devel/1.5.5/scribus-1.5.5-windows-x64.exe/download"
+    )

--- a/poster/scripts/sla_to_pdf.py
+++ b/poster/scripts/sla_to_pdf.py
@@ -1,5 +1,6 @@
 import scribus
-scribus.openDoc('poster/template.sla')
+
+scribus.openDoc("poster/template.sla")
 pdf = scribus.PDFfile()
-pdf.file = 'poster.pdf'
+pdf.file = "poster.pdf"
 pdf.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 120
+skip-magic-trailing-comma = true
+exclude = '''
+/(
+  | venv
+)/
+'''

--- a/video/scripts/moviemaker.py
+++ b/video/scripts/moviemaker.py
@@ -1,23 +1,40 @@
 import os
-import numpy as np
-from multiprocessing import cpu_count, Pool
-from multiprocessing.dummy import Pool as ThreadPool
 import warnings
-from poster.scripts.imaging import ImagingLofar
-import cv2 as cv
 from glob import glob
+from multiprocessing import Pool
+from multiprocessing.dummy import Pool as ThreadPool
+
+import cv2 as cv
+import numpy as np
 from termcolor import colored
+
+from poster.scripts.imaging import ImagingLofar
+
 warnings.filterwarnings("ignore")
 
-__all__ = ['MovieMaker']
+__all__ = ["MovieMaker"]
+
 
 class MovieMaker(ImagingLofar):
     """
     MovieMaker makes it possible to make individual frames and turn them into a video.
     """
-    def __init__(self, fits_file: str = None, imsize: float = None, framerate: float = None, process: str = None,
-                 fits_download: bool=False, new: bool = True, text: str = None, vmin: float = None, vmax: float = None, zoom_effect: bool = False,
-                 output_file: str = 'frames', cmap: str = None):
+
+    def __init__(
+        self,
+        fits_file: str = None,
+        imsize: float = None,
+        framerate: float = None,
+        process: str = None,
+        fits_download: bool = False,
+        new: bool = True,
+        text: str = None,
+        vmin: float = None,
+        vmax: float = None,
+        zoom_effect: bool = False,
+        output_file: str = "frames",
+        cmap: str = None,
+    ):
         """
         :param fits_file: fits file name
         :param imsize: initial image size
@@ -27,7 +44,15 @@ class MovieMaker(ImagingLofar):
         :param cmap: choose your favorite cmap
         """
         self.output_file = output_file
-        super().__init__(fits_file = fits_file, image_directory=self.output_file, verbose=False, fits_download=fits_download, vmin=vmin, vmax=vmax, zoom_effect=zoom_effect)
+        super().__init__(
+            fits_file=fits_file,
+            image_directory=self.output_file,
+            verbose=False,
+            fits_download=fits_download,
+            vmin=vmin,
+            vmax=vmax,
+            zoom_effect=zoom_effect,
+        )
         self.process = process
         self.imsize = imsize
         self.framerate = framerate
@@ -39,10 +64,9 @@ class MovieMaker(ImagingLofar):
         if cmap:
             self.cmap = cmap
         else:
-            self.cmap = 'CMRmap'
+            self.cmap = "CMRmap"
         if new:
-            os.system(f'rm -rf {output_file}; mkdir {output_file}')
-
+            os.system(f"rm -rf {output_file}; mkdir {output_file}")
 
     def __call__(self, imsize: float = None, process: str = None):
         """
@@ -55,27 +79,27 @@ class MovieMaker(ImagingLofar):
         :param process: process [multiprocess, multithread, None]
         """
         if imsize:
-            self.imsize=imsize
-            print(f'Current image size: {self.imsize}')
+            self.imsize = imsize
+            print(f"Current image size: {self.imsize}")
         if process:
-            self.process=process
-            print(f'Process: {self.process}')
+            self.process = process
+            print(f"Process: {self.process}")
         pass
 
     def __getstate__(self):
-        """ This is called before pickling"""
-        if self.process=='multiprocess':
+        """This is called before pickling."""
+        if self.process == "multiprocess":
             state = self.__dict__.copy()
-            del state['hdu']
+            del state["hdu"]
             return state
 
     def __setstate__(self, state):
-        """ This is called while unpickling. """
+        """This is called while unpickling."""
         self.__dict__.update(state)
 
-    def make_frame(self, N, ra = None, dec = None, imsize: float = None, dpi: float = 300):
+    def make_frame(self, N, ra=None, dec=None, imsize: float = None, dpi: float = 300):
         """
-        Make seperate frame (image)
+        Make separate frame (image)
         ------------------------------------------------------------
         :param N: image number
         :param ra: right ascension (degrees)
@@ -83,22 +107,30 @@ class MovieMaker(ImagingLofar):
         :param imsize: image size (pixel or degree size)
         :param dpi: dots per inch (pixel density)
         """
-        print(colored(f"Frame number: {N-self.N_min}/{self.N_max-self.N_min}", 'red'), end='\r')
 
-        ## reduce jitter by always having a central pixel (force odd size)
-        size1 = np.int(imsize/np.max(self.wcs.pixel_scale_matrix))
-        size2 = np.int(imsize/np.max(self.wcs.pixel_scale_matrix)*1.77)
-        if size1%2 == 0:
+        # Uncomment for e.g. debugging or testing a new path
+        # if N == 20:
+        #     import sys
+        #     sys.exit('Frame limit reached, exiting program')
+
+        print(colored(f"Frame number: {N - self.N_min}/{self.N_max - self.N_min}", "red"), end="\r")
+
+        # reduce jitter by always having a central pixel (force odd size)
+        size1 = np.int(imsize / np.max(self.wcs.pixel_scale_matrix))
+        size2 = np.int(imsize / np.max(self.wcs.pixel_scale_matrix) * 1.77)
+        if size1 % 2 == 0:
             size1 = size1 + 1
-        if size2%2 == 0:
+        if size2 % 2 == 0:
             size2 = size2 + 1
-        self.image_cutout(pos=(ra, dec),
-                          size=(size1,size2),
-                          dpi=dpi,
-                          image_name=f'image_{str(N).rjust(5, "0")}.png',
-                          cmap=self.cmap,
-                          text=self.text,
-                          imsize=imsize)
+        self.image_cutout(
+            pos=(ra, dec),
+            size=(size1, size2),
+            dpi=dpi,
+            image_name=f'image_{str(N).rjust(5, "0")}.png',
+            cmap=self.cmap,
+            text=self.text,
+            imsize=imsize,
+        )
         return self
 
     def make_frames(self):
@@ -106,38 +138,52 @@ class MovieMaker(ImagingLofar):
         Record individual frames and save in frames/
         ------------------------------------------------------------
         """
-        self.N_max = len(os.listdir(self.output_file))+len(self.ragrid) #max number of videos
-        self.N_min = len(os.listdir(self.output_file)) #min number of videos
-        inputs = zip(range(self.N_min, self.N_max), self.ragrid, self.decgrid, self.imsizes,
-                     np.clip(200/np.array(self.imsizes), a_min=450, a_max=700).astype(int))
 
-        print('-------------------------------------------------')
-        print(colored(f'Imaging {len(self.ragrid)} frames for current move.', 'green'))
+        total_frames = 0  # Total number of frames currently made
+        with os.scandir(self.output_file) as it:
+            for entry in it:
+                if entry.is_file():
+                    total_frames += 1
+
+        self.N_max = total_frames + len(self.ragrid)  # max number of videos
+        self.N_min = total_frames  # min number of videos
+        inputs = zip(
+            range(self.N_min, self.N_max),
+            self.ragrid,
+            self.decgrid,
+            self.imsizes,
+            np.clip(200 / np.array(self.imsizes), a_min=450, a_max=700).astype(int),
+        )
+
+        print("-------------------------------------------------")
+        print(colored(f"Imaging {len(self.ragrid)} frames for current move.", "green"))
 
         if self.process == "multithread":
             print(f"Multithreading")
             print(f"Might get error or bad result because multithreading is difficult with imaging.")
             with ThreadPool(8) as p:
                 p.starmap(self.make_frame, inputs)
-        elif self.process == 'multiprocess':
-            cpus=2
+        elif self.process == "multiprocess":
+            cpus = 2
             print(f"You are using {cpus} cpu's for multiprocessing")
+
             def chunked_input(input, chunksize):
                 input = list(input)
-                input_out=[]
+                input_out = []
                 for r in range(chunksize):
-                    input_out +=input[r::chunksize]
+                    input_out += input[r::chunksize]
                 del input
                 return input_out
+
             try:
                 with Pool(cpus) as p:
-                    p.starmap(self.make_frame, chunked_input(inputs,cpus), chunksize=cpus)
-            except:
+                    p.starmap(self.make_frame, chunked_input(inputs, cpus), chunksize=cpus)
+            except BaseException:
                 pass
         else:
             for inp in inputs:
                 self.make_frame(inp[0], inp[1], inp[2], inp[3], inp[4])
-        print('-------------------------------------------------')
+        print("-------------------------------------------------")
         return self
 
     def move_to(self, first_time: bool = False, ra: float = None, dec: float = None, N_frames: int = None):
@@ -154,19 +200,27 @@ class MovieMaker(ImagingLofar):
         else:
             start_ra, start_dec = self.ra, self.dec
         self.ra, self.dec = ra, dec
-        if ra>start_ra:
-            self.ragrid = np.linspace(start_ra, ra, N_frames)  # deg
+        if ra > start_ra:
+            if ra - start_ra > 180:  # Taking shortest path by crossing zero meridian
+                ragrid_temp = start_ra - np.linspace(0, start_ra + 360 - ra, N_frames)
+                self.ragrid = np.where(ragrid_temp < 0, ragrid_temp + 360, ragrid_temp)  # deg
+            else:
+                self.ragrid = np.linspace(start_ra, ra, N_frames)  # deg
         else:
-            self.ragrid = np.linspace(ra, start_ra, N_frames)[::-1]
-        if dec>start_dec:
+            if start_ra - ra > 180:  # Taking shortest path by crossing zero meridian
+                ragrid_temp = start_ra + np.linspace(0, ra + 360 - start_ra, N_frames)
+                self.ragrid = np.where(ragrid_temp > 360, ragrid_temp - 360, ragrid_temp)  # deg
+            else:
+                self.ragrid = np.linspace(ra, start_ra, N_frames)[::-1]
+        if dec > start_dec:
             self.decgrid = np.linspace(start_dec, dec, N_frames)  # deg
         else:
             self.decgrid = np.linspace(dec, start_dec, N_frames)[::-1]
-        self.imsizes = [self.imsize]*N_frames
+        self.imsizes = [self.imsize] * N_frames
         self.make_frames()
         return self
 
-    def zoom(self, N_frames: int = None, first_time: bool=False, imsize_out: float = None, full_im: bool = False):
+    def zoom(self, N_frames: int = None, first_time: bool = False, imsize_out: float = None, full_im: bool = False):
         """
         Zoom in.
         ------------------------------------------------------------
@@ -178,9 +232,9 @@ class MovieMaker(ImagingLofar):
         if first_time:
             begin_size = self.image_data.shape[0] * np.max(self.wcs.pixel_scale_matrix)
             if not full_im:
-                begin_size/=2
+                begin_size /= 2
             end_size = self.imsize
-            coordinates = self.wcs.pixel_to_world(int(self.image_data.shape[1]/2), int(self.image_data.shape[0]/2))
+            coordinates = self.wcs.pixel_to_world(int(self.image_data.shape[1] / 2), int(self.image_data.shape[0] / 2))
             self.dec = coordinates.dec.degree
             self.ra = coordinates.ra.degree
         else:
@@ -188,8 +242,8 @@ class MovieMaker(ImagingLofar):
             end_size = imsize_out
         self.imsizes = np.linspace(begin_size, end_size, N_frames)
         self.imsize = self.imsizes[-1]
-        self.ragrid = np.array([self.ra]*len(self.imsizes))
-        self.decgrid = np.array([self.dec]*len(self.imsizes))
+        self.ragrid = np.array([self.ra] * len(self.imsizes))
+        self.decgrid = np.array([self.dec] * len(self.imsizes))
         self.make_frames()
         return self
 
@@ -213,46 +267,54 @@ class MovieMaker(ImagingLofar):
         ------------------------------------------------------------
         :param audio: add audio (True or False).
         """
-        os.system(f'rm movie.mp4; ffmpeg -f image2 -r {self.framerate} -start_number 0 -i {self.output_file}/image_%05d.png movie.mp4')
+        os.system(
+            f"rm movie.mp4; ffmpeg -f image2 -r {self.framerate} -start_number 0 -i {self.output_file}/image_%05d.png movie.mp4"
+        )
+
         if audio:
             try:
                 audio_file = input(audio)
-                os.system(f'ffmpeg -i movie.mp4 -i {audio_file} -t 65 audiomovie.mp4')
-            except:
-                print('Audio file does not exist')
+                os.system(f"ffmpeg -i movie.mp4 -i {audio_file} -t 65 audiomovie.mp4")
+            except BaseException:
+                print("Audio file does not exist")
         return self
 
-def crop_center(img,cropx,cropy):
-    y,x,_ = img.shape
-    startx = x//2-(cropx//2)
-    starty = y//2-(cropy//2)
-    return img[starty:starty+cropy,startx:startx+cropx,:]
+
+def crop_center(img, cropx, cropy):
+    y, x, _ = img.shape
+    startx = x // 2 - (cropx // 2)
+    starty = y // 2 - (cropy // 2)
+    return img[starty : starty + cropy, startx : startx + cropx, :]
+
 
 def fading_effect(source, frames):
-    images = glob('/home/jurjen/Documents/Python/advanced_astro_visualization/frames_high/*')
+    images = glob("/home/jurjen/Documents/Python/advanced_astro_visualization/frames_high/*")
     img1 = cv.imread(sorted(images)[-1])
-    img1 = cv.GaussianBlur(img1, (5,5), 0)
-    img2 = cv.imread(glob(f'/home/jurjen/Documents/Python/advanced_astro_visualization/fits/highres_P205/{source}*MFS-image.png')[0])
+    img1 = cv.GaussianBlur(img1, (5, 5), 0)
+    img2 = cv.imread(
+        glob(f"/home/jurjen/Documents/Python/advanced_astro_visualization/fits/highres_P205/{source}*MFS-image.png")[0]
+    )
 
-    #add extra empty rows to reshape img2
-    add_rows = int((img1.shape[1]/img1.shape[0]*img2.shape[1]-img2.shape[1])/2)
-    new = np.zeros((img2.shape[0], img2.shape[1]+add_rows*2, 3), dtype=np.float32)
-    new[:, add_rows:new.shape[1]-add_rows, :] = img2
+    # add extra empty rows to reshape img2
+    add_rows = int((img1.shape[1] / img1.shape[0] * img2.shape[1] - img2.shape[1]) / 2)
+    new = np.zeros((img2.shape[0], img2.shape[1] + add_rows * 2, 3), dtype=np.float32)
+    new[:, add_rows : new.shape[1] - add_rows, :] = img2
     img2 = new
-    #resize now img2
-    img1 = cv.resize(img1, (img2.shape[1], img2.shape[0]), interpolation=cv.INTER_AREA) # reshape image
-    for i in np.append(np.linspace(0, 1, frames//2), np.linspace(0, 1, frames//2)[::-1]):
+    # resize now img2
+    img1 = cv.resize(img1, (img2.shape[1], img2.shape[0]), interpolation=cv.INTER_AREA)  # reshape image
+    for i in np.append(np.linspace(0, 1, frames // 2), np.linspace(0, 1, frames // 2)[::-1]):
         alpha = i
         beta = 1 - alpha
         output = cv.addWeighted(img2, alpha, img1, beta, 0, dtype=cv.CV_32F)
-        output = crop_center(output, int((1 - i/4) * output.shape[1]), int((1 - i/4) * output.shape[0]))
-        n=1
-        if alpha==1:
-            n=frames//6
+        output = crop_center(output, int((1 - i / 4) * output.shape[1]), int((1 - i / 4) * output.shape[0]))
+        n = 1
+        if alpha == 1:
+            n = frames // 6
         for r in range(n):
-            images = glob('/home/jurjen/Documents/Python/advanced_astro_visualization/frames_high/*')
+            images = glob("/home/jurjen/Documents/Python/advanced_astro_visualization/frames_high/*")
             new_im_name = f'/home/jurjen/Documents/Python/advanced_astro_visualization/frames_high/image_{str(len(images)).rjust(5, "0")}.png'
             cv.imwrite(new_im_name, output)
 
-if __name__ == '__main__':
-    print('Cannot call script directly.')
+
+if __name__ == "__main__":
+    print("Cannot call script directly.")


### PR DESCRIPTION
The class ScanPaths in paths.py is a way to easily make custom paths over LOFAR pointings. Two paths have already been made: a horizontally sweeping scan and a spiral inwards. 

Three arguments are added to the parser to add some flexibility in making the movies: zoomsize, degrate and scan. The video starts and ends with a zoom, zoomsize is the zoomed image size in degrees. Degrate (degree rate) is the amount of degrees traversed each second, so it controls the speed of the movie. Finally, scan is a string that can be added to select a premade scanning path (now either 'horizontal' or 'spiral', defaults to 'horizontal').

The code can now also take the shortest path when crossing the prime meridian. Before, it went from 359 deg to 2 deg the long way around. This bug is fixed in the script moviemaker.py.